### PR TITLE
- Replace deprecated 'hiera_hash' to 'lookup'.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,11 @@ class wget (
   String  $package_ensure = $wget::params::package_ensure,
   String  $package_name   = $wget::params::package_name,
   Hash[String, Hash[String, String]]
-          $retrievals     = hiera_hash('wget::retrieve', {}),
+          $retrievals     = lookup('wget::retrieve', Hash, 'hash', {}),
 ) inherits wget::params {
 
-  anchor { "${module_name}::begin": } ->
-    class { "${module_name}::install": } ->
-    class { "${module_name}::config": } ->
-  anchor { "${module_name}::end": }
+  anchor { "${module_name}::begin": }
+  -> class { "${module_name}::install": }
+  -> class { "${module_name}::config": }
+  -> anchor { "${module_name}::end": }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -93,7 +93,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
- Update minimum puppet version required is set to 4.7.0.
- Fix style errors that are due to the new chaining arrow style introduced with Puppet 4.9.