### PR TITLE
Bumping `puppetlabs-stdlib` version requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Updated the version requirements for `puppetlabs-stdlib` to anything as high as the 9.x series.