### PR TITLE
- Lift maximum `puppet` version to limit to 9.0.0.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -36,10 +36,6 @@ appveyor.yml:
       collection: puppet7
     - set: ubuntu1804-64
       collection: puppet6
-    - set: ubuntu1604-64
-      collection: puppet7
-    - set: ubuntu1604-64
-      collection: puppet6
     - set: debian11-64
       collection: puppet7
     - set: debian11-64
@@ -47,10 +43,6 @@ appveyor.yml:
     - set: debian10-64
       collection: puppet7
     - set: debian10-64
-      collection: puppet6
-    - set: debian9-64
-      collection: puppet7
-    - set: debian9-64
       collection: puppet6
     #    - set: almalinux9-64
     #      collection: puppet7

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,24 +85,6 @@ jobs:
     -
       bundler_args: --with system_tests
       dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=ubuntu1604-64 BEAKER_TESTMODE=apply
-      rvm: 2.5.7
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=ubuntu1604-64 BEAKER_TESTMODE=apply
-      rvm: 2.5.7
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: focal
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=debian11-64 BEAKER_TESTMODE=apply
       rvm: 2.5.7
       script: bundle exec rake beaker
@@ -131,24 +113,6 @@ jobs:
       bundler_args: --with system_tests
       dist: focal
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=debian10-64 BEAKER_TESTMODE=apply
-      rvm: 2.5.7
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=debian9-64 BEAKER_TESTMODE=apply
-      rvm: 2.5.7
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=debian9-64 BEAKER_TESTMODE=apply
       rvm: 2.5.7
       script: bundle exec rake beaker
       services: docker

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 6.0.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -51,7 +51,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]
@@ -59,7 +58,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04",
         "22.04"
@@ -78,7 +76,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
- Updated minimum `stdlib` version to `7.0.0` and lift the max limit to 10.0.0.
- Fix for #37 